### PR TITLE
feat : 등록&수정 페이지 - 우편 번호 서비스 추가

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -13,6 +13,11 @@ export default function Document() {
           type="text/javascript"
           src="//dapi.kakao.com/v2/maps/sdk.js?appkey=9cc2180d1a6fff2ed649d23c22fe9e83&libraries=services&autoload=false"
         />
+        <Script
+          type="text/javascript"
+          strategy="beforeInteractive"
+          src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"
+        />
       </Head>
       <body>
         <Main />

--- a/pages/test/index.tsx
+++ b/pages/test/index.tsx
@@ -1,11 +1,11 @@
 import ActivityContentSkeleton from "@/Components/ActivityDetails/ActivityContentSkeleton";
 import ReviewSkeleton from "@/Components/ActivityDetails/ReviewSkeleton";
+import AddressSearch from "@/Components/ActivityRegist/AddressPostcode";
 
 const test = () => {
   return (
     <>
-      <ActivityContentSkeleton />
-      <ReviewSkeleton />
+      <AddressSearch />
     </>
   );
 };

--- a/src/Components/ActivityEdit/ActivityEditInfo.tsx
+++ b/src/Components/ActivityEdit/ActivityEditInfo.tsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
 
+declare global {
+  interface Window {
+    daum: any;
+  }
+}
+
 interface ActivityEditInfoProps {
   title: string;
   category: string;
@@ -18,10 +24,21 @@ const ActivityEditInfo = ({
   handleFormData,
 }: ActivityEditInfoProps) => {
   const [selectedCategory, setSelectedCategory] = useState("카테고리");
+  const [newAddress, setNewAddress] = useState<string>(address);
 
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedCategory(e.target.value);
     handleFormData("category", e.target.value);
+  };
+
+  const openDaumPostcode = () => {
+    new window.daum.Postcode({
+      oncomplete: (data: any) => {
+        const selectedAddress = data.address;
+        setNewAddress(selectedAddress);
+        handleFormData("address", selectedAddress);
+      },
+    }).open();
   };
 
   return (
@@ -65,9 +82,10 @@ const ActivityEditInfo = ({
         <label className="text-2xl font-bold text-gnDarkBlack">주소</label>
         <input
           className="rounded border border-gnGray700 bg-white px-4 py-[15px] text-base font-normal"
-          defaultValue={address}
+          value={newAddress}
           placeholder="주소"
-          onBlur={(e) => handleFormData("address", e.target.value)}
+          onClick={openDaumPostcode}
+          readOnly
         />
       </div>
     </div>

--- a/src/Components/ActivityRegist/ActicityRegistInfo.tsx
+++ b/src/Components/ActivityRegist/ActicityRegistInfo.tsx
@@ -1,15 +1,30 @@
 import { useState } from "react";
 
+declare global {
+  interface Window {
+    daum: any;
+  }
+}
+
 interface ActivityRegistInfoProps {
   handleFormData: (name: string, value: string | number) => void;
 }
 
 const ActivityRegistInfo = ({ handleFormData }: ActivityRegistInfoProps) => {
   const [selectedCategory, setSelectedCategory] = useState("카테고리");
+  const [address, setAddress] = useState("");
 
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedCategory(e.target.value);
     handleFormData("category", e.target.value);
+  };
+
+  const openDaumPostcode = () => {
+    new window.daum.Postcode({
+      oncomplete: (data: any) => {
+        setAddress(data.address);
+      },
+    }).open();
   };
 
   return (
@@ -51,7 +66,10 @@ const ActivityRegistInfo = ({ handleFormData }: ActivityRegistInfoProps) => {
         <input
           className="rounded border border-gnGray700 bg-white px-4 py-[15px] text-base font-normal"
           placeholder="주소"
+          value={address}
           onBlur={(e) => handleFormData("address", e.target.value)}
+          onClick={openDaumPostcode}
+          readOnly
         />
       </div>
     </div>

--- a/src/Components/ActivityRegist/ActicityRegistInfo.tsx
+++ b/src/Components/ActivityRegist/ActicityRegistInfo.tsx
@@ -22,7 +22,9 @@ const ActivityRegistInfo = ({ handleFormData }: ActivityRegistInfoProps) => {
   const openDaumPostcode = () => {
     new window.daum.Postcode({
       oncomplete: (data: any) => {
-        setAddress(data.address);
+        const selectedAddress = data.address;
+        setAddress(selectedAddress);
+        handleFormData("address", selectedAddress);
       },
     }).open();
   };
@@ -67,7 +69,6 @@ const ActivityRegistInfo = ({ handleFormData }: ActivityRegistInfoProps) => {
           className="rounded border border-gnGray700 bg-white px-4 py-[15px] text-base font-normal"
           placeholder="주소"
           value={address}
-          onBlur={(e) => handleFormData("address", e.target.value)}
           onClick={openDaumPostcode}
           readOnly
         />

--- a/src/Components/ActivityRegist/AddressPostcode.tsx
+++ b/src/Components/ActivityRegist/AddressPostcode.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+
+declare global {
+  interface Window {
+    daum: any;
+  }
+}
+
+const AddressSearch = () => {
+  const [postcode, setPostcode] = useState("");
+  const [address, setAddress] = useState("");
+
+  const openDaumPostcode = () => {
+    new window.daum.Postcode({
+      oncomplete: (data: any) => {
+        setPostcode(data.zonecode);
+        setAddress(data.address);
+      },
+    }).open();
+  };
+
+  return (
+    <div>
+      <input type="text" value={postcode} readOnly placeholder="우편번호" />
+      <input type="text" value={address} readOnly placeholder="주소" />
+      <button type="button" onClick={openDaumPostcode}>
+        주소 검색
+      </button>
+    </div>
+  );
+};
+
+export default AddressSearch;


### PR DESCRIPTION
## #️⃣연관된 이슈

> -  ex)  - #이슈번호

## 📝작업 내용

> 등록&수정 페이지 주소 입력 시 아래 사진과 같은 주소 검색창이 렌더링, 주소 선택 시 인풋이 해당 주소로 채워짐.

### 스크린샷 (선택)
![다음 우편 번호 서비스](https://github.com/Globalnomad-17/team17-globalnomad/assets/82919729/4a5ad667-1d06-4af9-9bbb-2e79d5b1dd20)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?